### PR TITLE
Progress on Adding EdDSA Signatures for TLS Notary Protocol

### DIFF
--- a/notary-server/src/domain/notary.rs
+++ b/notary-server/src/domain/notary.rs
@@ -24,6 +24,8 @@ pub struct NotarizationSessionRequest {
     pub max_sent_data: Option<usize>,
     /// Maximum data that can be received by the prover
     pub max_recv_data: Option<usize>,
+    /// Message to sign
+    pub message: Option<String>,
 }
 
 /// Request query of the /notarize API
@@ -49,6 +51,7 @@ pub struct SessionData {
     pub max_sent_data: Option<usize>,
     pub max_recv_data: Option<usize>,
     pub created_at: DateTime<Utc>,
+    pub message: Option<String>,
 }
 
 /// Global data that needs to be shared with the axum handlers

--- a/notary-server/src/service/tcp.rs
+++ b/notary-server/src/service/tcp.rs
@@ -83,6 +83,7 @@ pub async fn tcp_notarize(
     stream: TokioIo<Upgraded>,
     notary_globals: NotaryGlobals,
     session_id: String,
+    message: Option<String>,
     max_sent_data: Option<usize>,
     max_recv_data: Option<usize>,
 ) {
@@ -91,6 +92,7 @@ pub async fn tcp_notarize(
         stream,
         &notary_globals.notary_signing_key,
         &session_id,
+        message,
         max_sent_data,
         max_recv_data,
     )

--- a/notary-server/src/service/websocket.rs
+++ b/notary-server/src/service/websocket.rs
@@ -11,6 +11,7 @@ pub async fn websocket_notarize(
     socket: WebSocket,
     notary_globals: NotaryGlobals,
     session_id: String,
+    message: Option<String>,
     max_sent_data: Option<usize>,
     max_recv_data: Option<usize>,
 ) {
@@ -21,6 +22,7 @@ pub async fn websocket_notarize(
         stream,
         &notary_globals.notary_signing_key,
         &session_id,
+        message,
         max_sent_data,
         max_recv_data,
     )

--- a/tlsn/tlsn-core/src/msg.rs
+++ b/tlsn/tlsn-core/src/msg.rs
@@ -27,6 +27,8 @@ pub struct SignedSessionHeader {
     pub header: SessionHeader,
     /// The notary's signature
     pub signature: Signature,
+    /// The session message signature
+    pub message_sig: Signature,
 }
 
 /// Information about the values the prover wants to prove

--- a/tlsn/tlsn-core/src/session/mod.rs
+++ b/tlsn/tlsn-core/src/session/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 pub struct NotarizedSession {
     header: SessionHeader,
     signature: Option<Signature>,
+    message_sig: Option<Signature>,
     data: SessionData,
 }
 
@@ -27,10 +28,11 @@ opaque_debug::implement!(NotarizedSession);
 
 impl NotarizedSession {
     /// Create a new notarized session.
-    pub fn new(header: SessionHeader, signature: Option<Signature>, data: SessionData) -> Self {
+    pub fn new(header: SessionHeader, signature: Option<Signature>, message_sig: Option<Signature>, data: SessionData) -> Self {
         Self {
             header,
             signature,
+            message_sig,
             data,
         }
     }
@@ -57,6 +59,11 @@ impl NotarizedSession {
     /// Returns the signature for the session header, if the notary signed it
     pub fn signature(&self) -> &Option<Signature> {
         &self.signature
+    }
+
+    /// Returns the signature for the session header, if the notary signed it
+    pub fn message_sig(&self) -> &Option<Signature> {
+        &self.message_sig
     }
 
     /// Returns the [SessionData]

--- a/tlsn/tlsn-prover/src/tls/notarize.rs
+++ b/tlsn/tlsn-prover/src/tls/notarize.rs
@@ -87,7 +87,7 @@ impl Prover<Notarize> {
         })
         .fuse();
 
-        let (notary_encoder_seed, SignedSessionHeader { header, signature }) = futures::select_biased! {
+        let (notary_encoder_seed, SignedSessionHeader { header, signature, message_sig }) = futures::select_biased! {
             res = notarize_fut => res?,
             _ = ot_fut => return Err(OTShutdownError)?,
             _ = &mut mux_fut => return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?,
@@ -110,6 +110,6 @@ impl Prover<Notarize> {
                 )
             })?;
 
-        Ok(NotarizedSession::new(header, Some(signature), session_data))
+        Ok(NotarizedSession::new(header, Some(signature), Some(message_sig), session_data))
     }
 }

--- a/tlsn/tlsn-verifier/src/tls/config.rs
+++ b/tlsn/tlsn-verifier/src/tls/config.rs
@@ -16,6 +16,8 @@ use tlsn_core::proof::default_cert_verifier;
 pub struct VerifierConfig {
     #[builder(setter(into))]
     id: String,
+    #[builder(setter(into))]
+    message: String,
     /// Maximum number of bytes that can be sent.
     #[builder(default = "DEFAULT_MAX_SENT_LIMIT")]
     max_sent_data: usize,
@@ -50,6 +52,11 @@ impl VerifierConfig {
     /// Returns the ID of the notarization session.
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    /// Returns the ID of the notarization session.
+    pub fn message(&self) -> &str {
+        &self.message
     }
 
     /// Returns the maximum number of bytes that can be sent.

--- a/tlsn/tlsn-verifier/src/tls/notarize.rs
+++ b/tlsn/tlsn-verifier/src/tls/notarize.rs
@@ -41,6 +41,7 @@ impl Verifier<Notarize> {
             sent_len,
             recv_len,
         } = self.state;
+        let message = self.config.message();
 
         let notarize_fut = async {
             let mut notarize_channel = mux_ctrl.get_channel("notarize").await?;
@@ -80,6 +81,7 @@ impl Verifier<Notarize> {
             );
 
             let signature = signer.sign(&session_header.to_bytes());
+            let m_signature = signer.sign(&message.to_bytes());
 
             #[cfg(feature = "tracing")]
             info!("Signed session header");
@@ -88,6 +90,7 @@ impl Verifier<Notarize> {
                 .send(TlsnMessage::SignedSessionHeader(SignedSessionHeader {
                     header: session_header.clone(),
                     signature: signature.into(),
+                    message_sig: m_signature.into(),
                 }))
                 .await?;
 


### PR DESCRIPTION
## Summary
This PR documents the progress made towards modifying the TLS Notary protocol to provide attestations as signatures from the notary. The changes aim to support EdDSA signatures from the Rust implementation.

## Changes Implemented
1. **New Parameter in Request**:
    - A new parameter labeled `message` has been added.
    - This parameter is stored in the session and is accessible throughout the lifecycle of the verifier.

2. **New Parameter in Response**:
    - The `message_sig` parameter is retuened as notary response, ensuring it can be used by the prover.

## Remaining Tasks
1. **Key for Signing**:
    - Clarification is needed on which key should be used by the Notary to sign the message.
    - Current assumption: The Notary's private key should be used, but confirmation and specification are required.

2. **Commitment Roles**:
    - Understanding and defining the roles of commitments in the new attestation process.
    - Determining how the commitments should be verified and opened before the Notary signs the attestation.

## Request for Feedback
- Guidance on how keys should be used for signing the attestation message.
- Detailed explanation of the commitment roles and how they should be integrated with the new attestation process.

## Next Steps
- Complete the integration of EdDSA signatures once the above points are clarified.
- Update relevant documentation and tests to reflect the new changes.

## How to Test
1. **New Parameter**:
    - Ensure the `message` parameter is correctly stored and accessible in the session config.
2. **Signature Verification**:
    - Verify that the Notary signs the message correctly using the specified key (once clarified).
